### PR TITLE
Cleared cached selection and panel stack on menu close, and disable t…

### DIFF
--- a/Runtime/Scripts/Menutee/MenuManager.cs
+++ b/Runtime/Scripts/Menutee/MenuManager.cs
@@ -58,6 +58,11 @@ namespace Menutee {
 		}
 
 		public void SetMenuUp(bool newUp) {
+			// Menu is closed.
+			if (!newUp) {
+				_cachedSelection = null;
+				_panelStack.Clear();
+			}
 			_active = newUp;
 			Canvas.enabled = newUp;
 			ActivatePanel(_active ? MenuConfig.MainPanelKey : null);
@@ -66,6 +71,7 @@ namespace Menutee {
 		public void SetMenuOnTop(bool newOnTop) {
 			if (!newOnTop) {
 				_cachedSelection = EventSystem.current.currentSelectedGameObject;
+				EventSystem.current.SetSelectedGameObject(null);
 			} else if(_cachedSelection != null) {
 				EventSystem.current.SetSelectedGameObject(_cachedSelection);
 			}


### PR DESCRIPTION
…he selected game object when the panel was no longer on top, ahead of where the panel was set not active. This fixes the case where the wrong element would be selected after closing a menu and fixes the pop action not working after closing while not on the root.