### PR TITLE
Resolve the "additions to PanelObjectConfig are breaking changes" issue.

### DIFF
--- a/Runtime/Scripts/Menutee/ButtonConfig.cs
+++ b/Runtime/Scripts/Menutee/ButtonConfig.cs
@@ -7,8 +7,8 @@ namespace Menutee {
 		public readonly string DisplayText;
 		public readonly ButtonPressedHandler Handler;
 
-		public ButtonConfig(string key, GameObject prefab, string displayText, System.Action<GameObject> creationCallback, ButtonPressedHandler handler, PaletteConfig paletteOverride = null) 
-				: base(key, prefab, creationCallback, paletteOverride) {
+		public ButtonConfig(InitObject configInit, string displayText, ButtonPressedHandler handler) 
+				: base(configInit) {
 			DisplayText = displayText;
 			Handler = handler;
 		}
@@ -44,7 +44,7 @@ namespace Menutee {
 			}
 
 			public override ButtonConfig Build() {
-				return new ButtonConfig(_key, _prefab, _displayText, _creationCallback, _handler, _paletteConfig);
+				return new ButtonConfig(BuildInitObject(), _displayText, _handler);
 			}
 		}
 	}

--- a/Runtime/Scripts/Menutee/DropdownConfig.cs
+++ b/Runtime/Scripts/Menutee/DropdownConfig.cs
@@ -8,8 +8,8 @@ namespace Menutee {
 		public readonly int DefaultIndex;
 		public readonly DropdownChosenHandler Handler;
 
-		public DropdownConfig(string key, GameObject prefab, string displayText, string[] optionStrings, int defaultIndex, System.Action<GameObject> creationCallback, DropdownChosenHandler handler, PaletteConfig paletteOverride = null) 
-				: base(key, prefab, creationCallback, paletteOverride) {
+		public DropdownConfig(InitObject configInit, string displayText, string[] optionStrings, int defaultIndex, DropdownChosenHandler handler) 
+				: base(configInit) {
 			DisplayText = displayText;
 			OptionStrings = optionStrings;
 			DefaultIndex = defaultIndex;
@@ -69,7 +69,7 @@ namespace Menutee {
 			}
 
 			public override DropdownConfig Build() {
-				return new DropdownConfig(_key, _prefab, _displayText, _optionStrings.ToArray(), _defaultIndex, _creationCallback, _handler, _paletteConfig);
+				return new DropdownConfig(BuildInitObject(), _displayText, _optionStrings.ToArray(), _defaultIndex, _handler);
 			}
 		}
 	}

--- a/Runtime/Scripts/Menutee/PanelObjectConfig.cs
+++ b/Runtime/Scripts/Menutee/PanelObjectConfig.cs
@@ -14,14 +14,28 @@ namespace Menutee {
 		public readonly PaletteConfig PaletteConfig;
 		public readonly GameObject Prefab;
 
-		public PanelObjectConfig(string key, GameObject prefab, Action<GameObject> creationCallback, PaletteConfig paletteConfig) {
-			Key = key;
-			CreationCallback = creationCallback;
-			PaletteConfig = paletteConfig;
-			Prefab = prefab;
+		public PanelObjectConfig(InitObject initObject) {
+			Key = initObject.Key;
+			CreationCallback = initObject.CreationCallback;
+			PaletteConfig = initObject.PaletteConfig;
+			Prefab = initObject.Prefab;
 		}
 
 		public abstract GameObject Create(GameObject parent);
+
+		public class InitObject {
+			public readonly string Key;
+			public readonly Action<GameObject> CreationCallback;
+			public readonly PaletteConfig PaletteConfig;
+			public readonly GameObject Prefab;
+
+			public InitObject(string key, GameObject prefab, Action<GameObject> creationCallback = null, PaletteConfig paletteConfig = null) {
+				Key = key;
+				CreationCallback = creationCallback;
+				PaletteConfig = paletteConfig;
+				Prefab = prefab;
+			}
+		}
 
 		public abstract class Builder<TObject, TBuilder> where TObject : PanelObjectConfig where TBuilder : Builder<TObject, TBuilder> {
 			protected string _key;
@@ -44,6 +58,10 @@ namespace Menutee {
 			public TBuilder SetCreationCallback(System.Action<GameObject> creationCallback) {
 				_creationCallback = creationCallback;
 				return _builderInstance;
+			}
+
+			public InitObject BuildInitObject() {
+				return new InitObject(_key, _prefab, _creationCallback, _paletteConfig);
 			}
 
 			public abstract TObject Build();

--- a/Runtime/Scripts/Menutee/SliderConfig.cs
+++ b/Runtime/Scripts/Menutee/SliderConfig.cs
@@ -11,8 +11,8 @@ namespace Menutee {
 		public bool UseWholeNumbers;
 		public SliderUpdatedHandler Handler;
 
-		public SliderConfig(string key, GameObject prefab, string displayText, bool useWholeNumbers, float minValue, float maxValue, float defaultValue, System.Action<GameObject> creationCallback, SliderUpdatedHandler handler, PaletteConfig paletteOverride = null) 
-				: base(key, prefab, creationCallback, paletteOverride) {
+		public SliderConfig(InitObject configInit, string displayText, bool useWholeNumbers, float minValue, float maxValue, float defaultValue, SliderUpdatedHandler handler) 
+				: base(configInit) {
 			DisplayText = displayText;
 			MinValue = minValue;
 			MaxValue = maxValue;
@@ -67,7 +67,7 @@ namespace Menutee {
 			}
 
 			public override SliderConfig Build() {
-				return new SliderConfig(_key, _prefab, _displayText, _useWholeNumbers, _minValue, _maxValue, _defaultValue, _creationCallback, _handler, _paletteConfig);
+				return new SliderConfig(BuildInitObject(), _displayText, _useWholeNumbers, _minValue, _maxValue, _defaultValue, _handler);
 			}
 		}
 	}

--- a/Runtime/Scripts/Menutee/ToggleConfig.cs
+++ b/Runtime/Scripts/Menutee/ToggleConfig.cs
@@ -8,8 +8,8 @@ namespace Menutee {
 		public readonly bool IsOn;
 		public readonly TogglePressedHandler Handler;
 
-		public ToggleConfig(string key, GameObject prefab, string displayText, bool isOn, System.Action<GameObject> creationCallback, TogglePressedHandler handler, PaletteConfig paletteOverride = null) 
-				: base(key, prefab, creationCallback, paletteOverride) {
+		public ToggleConfig(InitObject configInit, string displayText, bool isOn, TogglePressedHandler handler) 
+				: base(configInit) {
 			DisplayText = displayText;
 			IsOn = isOn;
 			Handler = handler;
@@ -53,7 +53,7 @@ namespace Menutee {
 			}
 
 			public override ToggleConfig Build() {
-				return new ToggleConfig(_key, _prefab, _displayText, _isOn, _creationCallback, _handler, _paletteConfig);
+				return new ToggleConfig(BuildInitObject(), _displayText, _isOn, _handler);
 			}
 		}
 	}

--- a/Samples~/Menu/Scripts/SampleMainMenu.cs
+++ b/Samples~/Menu/Scripts/SampleMainMenu.cs
@@ -23,13 +23,13 @@ public class SampleMainMenu : MenuGenerator {
 		// the builder you can specify it while adding the panel config.
 		MenuConfig config = new MenuConfig(false, false, MENU_KEY_MAIN, PaletteConfig, new PanelConfig[] {
 			new PanelConfig(MENU_KEY_MAIN, KEY_RESUME, new PanelObjectConfig[] {
-				new ButtonConfig(KEY_RESUME, ButtonPrefab, "Play Game", null, delegate(ButtonManager manager) {
+				new ButtonConfig(new PanelObjectConfig.InitObject(KEY_RESUME, ButtonPrefab), "Play Game", delegate(ButtonManager manager) {
 					Debug.Log("Play game pressed.");
 				}),
-				new ButtonConfig(KEY_OPTIONS, ButtonPrefab, "Options", null, delegate(ButtonManager manager) {
+				new ButtonConfig(new PanelObjectConfig.InitObject(KEY_OPTIONS, ButtonPrefab), "Options", delegate(ButtonManager manager) {
 					_manager.PushPanel(MENU_KEY_OPTIONS);
 				}),
-				new ButtonConfig(KEY_EXIT, ButtonPrefab, "Exit", null, delegate(ButtonManager manager) {
+				new ButtonConfig(new PanelObjectConfig.InitObject(KEY_EXIT, ButtonPrefab), "Exit",  delegate(ButtonManager manager) {
 					_manager.ExitGame();
 				})
 			}),


### PR DESCRIPTION
This, of course, is a breaking change for people creating menus without the builder and for PanelObjectConfig subclasses, but it should be the last one. PanelObjectConfig only takes a single object now, built by PanelObjectConfig.Builder (or manually if not using a builder). I don't love this solution, but it should solve all the problems I was running into (basically with a shadow PanelObjectConfig object).

Closes #15 