### PR TITLE
Add ability to run code after a 1 frame delay in MenuManager. 

### DIFF
--- a/Runtime/Scripts/Menutee/Managers/MenuManager.cs
+++ b/Runtime/Scripts/Menutee/Managers/MenuManager.cs
@@ -2,6 +2,8 @@
 using UnityEngine;
 using UnityEngine.EventSystems;
 using System.Linq;
+using System;
+using System.Collections;
 
 namespace Menutee {
 	public class MenuManager : MonoBehaviour, IMenu {
@@ -55,6 +57,21 @@ namespace Menutee {
 
 		public MenuAttributes GetMenuAttributes() {
 			return MenuConfig.MenuAttributes;
+		}
+
+		/// <summary>
+		/// Delays actions in the helper for a frame, since some things *COUGH* audio mixers *COUGH*
+		/// don't handle being set in awake properly. Useful for calling things from creation callbacks
+		/// for objects.
+		/// </summary>
+		/// <param name="doer">Thing to do after a frame.</param>
+		public void RunGenericActionAfterFrame(Action doer) {
+			StartCoroutine(GenericCoroutine(doer));
+        }
+
+		private IEnumerator GenericCoroutine(Action doer) {
+			yield return null;
+			doer?.Invoke();
 		}
 
 		public void SetMenuUp(bool newUp) {


### PR DESCRIPTION
This is so that generation scripts can have behavior that doesn't run on awake. I'm adding this because you can't set the volume mixer groups on awake for some reason so I need to run it after a delay. I figure if there's this case, there could be others.